### PR TITLE
Updated checks for less than and greater than

### DIFF
--- a/application/libraries/Validation.php
+++ b/application/libraries/Validation.php
@@ -488,7 +488,7 @@ class Validation  {
 		foreach ($fields as $v) {
 			$this->num($v, $err_msg);
 			if ($this->is_valid()) {
-				if ($this->data[$v] < $num) {
+				if ((int)$this->data[$v] > $num) {
 					$this->_error($err_msg, $v);
 				}
 			}
@@ -512,7 +512,7 @@ class Validation  {
 		foreach ($fields as $v) {
 			$this->num($v, $err_msg);
 			if ($this->is_valid()) {
-				if ($this->data[$v] > $num) {
+				if ((int)$this->data[$v] < $num) {
 					$this->_error($err_msg, $v);
 				}
 			}


### PR DESCRIPTION
example: I dont want field name to be less then 1.
```php
$prop->validation->num_lt(array("field_name"), 1, "required");
				if (!$prop->validation->is_valid()){
					$prop->helper->sendResponse(400, $prop->validation->get_error());
				}
```